### PR TITLE
Fix type error in GraphMetrics.java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,83 +16,50 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-	<groupId>flink</groupId>
-	<artifactId>flink-graphs</artifactId>
-	<version>1.0-SNAPSHOT</version>
-	<packaging>jar</packaging>
+    <parent>
+        <artifactId>impro3-ws14</artifactId>
+        <groupId>de.tu_berlin.dima</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
 
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-	</properties>
+    <artifactId>impro3-ws14-flink-graph</artifactId>
+    <name>IMPRO-3.WS14 (Flink-Graph API)</name>
 
-	<repositories>
-		<repository>
-			<id>apache.snapshots</id>
-			<name>Apache Development Snapshot Repository</name>
-			<url>https://repository.apache.org/content/repositories/snapshots/</url>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</repository>
-	</repositories>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
 
-	<!-- These two requirements are the minimum to use and develop Flink.
-		You can add others like <artifactId>pact-scala-core</artifactId> for Scala! -->
-	<dependencies>
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-java</artifactId>
-			<version>0.8-incubating-SNAPSHOT</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-clients</artifactId>
-			<version>0.8-incubating-SNAPSHOT</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-spargel</artifactId>
-			<version>0.8-incubating-SNAPSHOT</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-avro</artifactId>
-			<version>0.8-incubating-SNAPSHOT</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-test-utils</artifactId>
-			<version>0.8-incubating-SNAPSHOT</version>
-		</dependency>
-	    <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.11</version>
-            <type>jar</type>
-            <scope>test</scope>
+    <!-- These two requirements are the minimum to use and develop Flink.
+        You can add others like <artifactId>pact-scala-core</artifactId> for Scala! -->
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-java</artifactId>
+            <version>${flink.version}</version>
         </dependency>
-	</dependencies>
-
-	<!-- We use the maven-jar-plugin to generate a runnable jar that you can
-		submit to your Flink cluster. -->
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.1</version>
-				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-clients</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-spargel</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-avro</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-test-utils</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/src/main/java/flink/graphs/example/GraphMetrics.java
+++ b/src/main/java/flink/graphs/example/GraphMetrics.java
@@ -63,7 +63,7 @@ public class GraphMetrics implements ProgramDescription {
 		/** compute the average node degree **/
 		DataSet<Tuple2<Long, Long>> verticesWithDegrees = graph.getDegrees();
 
-		DataSet<Double> avgNodeDegree = verticesWithDegrees.project(1).types(Long.class)
+		DataSet<Double> avgNodeDegree = verticesWithDegrees.<Tuple1<Long>>project(1)
 				.aggregate(Aggregations.SUM, 0).map(new AvgNodeDegreeMapper())
 				.withBroadcastSet(numVertices, "numberOfVertices");
 		


### PR DESCRIPTION
How to reproduce:

    git clone git@github.com:TU-Berlin-DIMA/flink-graph.git
    cd flink-graph
    mvn clean install

Output:

    ...
    [ERROR] ~/flink-graph/src/main/java/flink/graphs/example/GraphMetrics.java:[67,64] method map in class org.apache.flink.api.java.DataSet<T> cannot be applied to given types;
    [ERROR] required: org.apache.flink.api.common.functions.MapFunction<org.apache.flink.api.java.tuple.Tuple,R>
    [ERROR] found: flink.graphs.example.GraphMetrics.AvgNodeDegreeMapper
    [ERROR] reason: no instance(s) of type variable(s) R exist so that argument type flink.graphs.example.GraphMetrics.AvgNodeDegreeMapper conforms to formal parameter type org.apache.flink.api.common.functions.MapFunction<org.apache.flink.api.java.tuple.Tuple,R>
    ...
